### PR TITLE
Fix/fat corruption oom

### DIFF
--- a/parser/context.go
+++ b/parser/context.go
@@ -100,9 +100,15 @@ func (self *FATContext) ListDirectoryComponents(
 		return nil, errors.New("Not a directory")
 	}
 
-	// The number of entries is related to the total size of the
-	// stream.
+	// Cap the number of entries to a safe maximum. file_size() for
+	// directories is derived from the cluster chain, but a corrupt
+	// chain that hits the volume-size bound still produces a large
+	// value; this prevents a runaway pre-allocation.
+	const maxDirectoryEntries = 65536
 	directory_size := int(stream.file_size()) / 32
+	if directory_size > maxDirectoryEntries {
+		directory_size = maxDirectoryEntries
+	}
 	return self.listDirectory(stream, directory_size), nil
 }
 

--- a/parser/stream.go
+++ b/parser/stream.go
@@ -24,9 +24,12 @@ func (self *FATReader) file_size() int64 {
 		return int64(len(self.runs)) * self.bytes_per_cluster
 	}
 
-	// Sometimes directories indicate that their size is 0 but this is
-	// not true.
-	if self.Info.IsDir && self.Info.Size == 0 {
+	// For directories, never trust the Size field from the directory
+	// entry. The FAT spec says it should always be 0; a non-zero value
+	// indicates corruption (e.g. garbage left in deleted or
+	// uninitialized entries). Derive the size from the cluster chain
+	// instead so that a garbage Size cannot cause a huge allocation.
+	if self.Info.IsDir {
 		return int64(len(self.runs)) * self.bytes_per_cluster
 	}
 
@@ -109,6 +112,9 @@ func (self *FATReader) readFAT12Entry(cluster int32) uint16 {
 func (self *FATReader) parseFAT12(first_cluster int32) error {
 	current_cluster := first_cluster
 	end_of_fat := self.offset_to_fat + self.total_fat_size
+	// A valid chain cannot be longer than the total number of clusters
+	// on the volume; exceeding this means the chain is circular.
+	max_clusters := self.context.total_sectors / self.context.Sectors_per_cluster
 
 	for {
 		next_cluster := self.readFAT12Entry(current_cluster)
@@ -126,8 +132,10 @@ func (self *FATReader) parseFAT12(first_cluster int32) error {
 		self.runs = append(self.runs, int64(next_cluster))
 		current_cluster = int32(next_cluster)
 
-		// The next cluster points outside the FAT!
-		if int64(next_cluster+next_cluster>>1) > end_of_fat {
+		// The next cluster points outside the FAT, or the chain
+		// exceeds the volume cluster count — circular/corrupt chain.
+		if int64(next_cluster+next_cluster>>1) > end_of_fat ||
+			int64(len(self.runs)) > max_clusters {
 			break
 		}
 	}
@@ -139,9 +147,9 @@ func (self *FATReader) parseFAT12(first_cluster int32) error {
 func (self *FATReader) parseFAT16(first_cluster int32) error {
 	current_cluster := first_cluster
 	end_of_fat := self.offset_to_fat + self.total_fat_size
-
-	max_number_of_clusters := int64(4) * 1024 * 1024 * 1024 /
-		self.context.Bytes_per_cluster
+	// A valid chain cannot be longer than the total number of clusters
+	// on the volume; exceeding this means the chain is circular.
+	max_clusters := self.context.total_sectors / self.context.Sectors_per_cluster
 
 	for {
 		next_cluster := ParseUint16(self.context.DiskReader,
@@ -160,9 +168,10 @@ func (self *FATReader) parseFAT16(first_cluster int32) error {
 		self.runs = append(self.runs, int64(next_cluster))
 		current_cluster = int32(next_cluster)
 
-		// The next cluster points outside the FAT!
+		// The next cluster points outside the FAT, or the chain
+		// exceeds the volume cluster count — circular/corrupt chain.
 		if int64(next_cluster)*2 > end_of_fat ||
-			int64(len(self.runs)) > max_number_of_clusters {
+			int64(len(self.runs)) > max_clusters {
 			break
 		}
 	}
@@ -174,9 +183,9 @@ func (self *FATReader) parseFAT16(first_cluster int32) error {
 func (self *FATReader) parseFAT32(first_cluster int32) error {
 	current_cluster := first_cluster
 	end_of_fat := self.offset_to_fat + self.total_fat_size
-
-	max_number_of_clusters := int64(4) * 1024 * 1024 * 1024 /
-		self.context.Bytes_per_cluster
+	// A valid chain cannot be longer than the total number of clusters
+	// on the volume; exceeding this means the chain is circular.
+	max_clusters := self.context.total_sectors / self.context.Sectors_per_cluster
 
 	for {
 		next_cluster := ParseUint32(self.context.DiskReader,
@@ -195,9 +204,10 @@ func (self *FATReader) parseFAT32(first_cluster int32) error {
 		self.runs = append(self.runs, int64(next_cluster))
 		current_cluster = int32(next_cluster)
 
-		// The next cluster points outside the FAT!
+		// The next cluster points outside the FAT, or the chain
+		// exceeds the volume cluster count — circular/corrupt chain.
 		if int64(next_cluster)*2 > end_of_fat ||
-			int64(len(self.runs)) > max_number_of_clusters {
+			int64(len(self.runs)) > max_clusters {
 			break
 		}
 	}


### PR DESCRIPTION
Hello there,

We had an Issue, where Windows.Detection.Bootloaders and Windows.Forensics.UEFI used > 10GB of Memory and never Finished. 

So to be honest with you, I though about letting Claude investigate it and fix it - he suspected that the issue is in go-fat and implemented these changes based on what other libraries do (Summary below)

I tested it on the machine where the issue happened (and also on one that did not have an issue yet to verify it didn't break existing stuff..) and it solved the Issue - the Artifacts don't consume 10 GB of Memory anymore and actually finish..

Feel free to accept or reject/modify however you want :)

--- 
Claude Summary
# Fix OOM when parsing corrupted FAT directory entries

## Problem

Parsing a FAT volume with corrupted or deleted directory entries could
cause the process to run out of memory. The root cause was in
`file_size()`:

```go
// before — only fell back to cluster chain when Size == 0
if self.Info.IsDir && self.Info.Size == 0 {
    return int64(len(self.runs)) * self.bytes_per_cluster
}
return int64(self.Info.Size)  // returned garbage for deleted/corrupt entries
```

The FAT spec states that a directory's `Size` field must always be `0`.
Corrupted or deleted directory entries can contain non-zero garbage there
instead. On the affected image, deleted installer temp directories (still
walked because they are visible in the directory listing) held
uninitialized data with `Size` values up to **2.7 GB**. This flowed into
`listDirectory` as the entry count (`size / 32 = ~87 million`), causing
`make([]*FolderEntry, 0, 87_000_000)` and an immediate OOM.

## Fixes

**Commit 1 — root cause (`file_size()`)**

For directories, always derive the size from the actual cluster chain and
ignore `Info.Size` entirely. This matches the behaviour of the Linux
kernel (`fat_calc_dir_size` always computes `(fclus + 1) << cluster_bits`)
and TSK.

**Commit 2 — hardening**

- Replace the fixed `4 GB / cluster_size` chain-length ceiling in
  `parseFAT12/16/32` with the actual volume cluster count
  (`total_sectors / sectors_per_cluster`). A valid chain can never exceed
  the total number of clusters on the volume, so this correctly terminates
  circular/runaway chains in O(1) extra memory — no hash map required.
  The Linux kernel uses the equivalent bound (`s_maxbytes >> cluster_bits`).
- Cap `ListDirectoryComponents` at 65 536 entries as a final safety net,
  so that even a corrupt chain reaching the volume bound cannot cause a
  pre-allocation larger than ~500 KB of pointers.

## References

- Linux kernel `fat_calc_dir_size`: https://github.com/torvalds/linux/blob/master/fs/fat/inode.c
- Linux kernel `fat_get_cluster` loop detection: https://android.googlesource.com/kernel/msm/+/android-msm-marlin-3.18-nougat-dr1/fs/fat/cache.c
- FAT spec (elm-chan): https://elm-chan.org/docs/fat_e.html
